### PR TITLE
Tom sellek.salto 3109.salesforce validate account settings against org wide defaults

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -77,6 +77,7 @@ import enumFieldPermissionsFilter from './filters/field_permissions_enum'
 import splitCustomLabels from './filters/split_custom_labels'
 import fetchFlowsFilter from './filters/fetch_flows'
 import customMetadataToObjectTypeFilter from './filters/custom_metadata_to_object_type'
+import organizationWideDefaults from './filters/organization_wide_sharing_defaults'
 import addDefaultActivateRSSFilter from './filters/add_default_activate_rss'
 import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
@@ -106,6 +107,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: customMetadataToObjectTypeFilter },
   // customObjectsFilter depends on missingFieldsFilter and settingsFilter
   { creator: customObjectsFromDescribeFilter, addsNewInformation: true },
+  { creator: organizationWideDefaults, addsNewInformation: true },
   // customSettingsFilter depends on customObjectsFilter
   { creator: customSettingsFilter, addsNewInformation: true },
   { creator: customObjectsToObjectTypeFilter },

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -34,6 +34,7 @@ import invalidListViewFilterScope from './change_validators/invalid_listview_fil
 import caseAssignmentRulesValidator from './change_validators/case_assignmentRules'
 import unknownUser from './change_validators/unknown_users'
 import animationRuleRecordType from './change_validators/animation_rule_recordtype'
+import accountSettings from './change_validators/account_settings'
 import SalesforceClient from './client/client'
 
 import { ChangeValidatorName, SalesforceConfig } from './types'
@@ -72,6 +73,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorDefini
   omitData: { creator: omitDataValidator, defaultInDeploy: false, defaultInValidate: true },
   unknownUser: { creator: (_config, _isSandbox, client) => unknownUser(client), ...defaultAlwaysRun },
   animationRuleRecordType: { creator: () => animationRuleRecordType, ...defaultAlwaysRun },
+  accountSettings: { creator: (_config, _isSandbox, client) => accountSettings(client), ...defaultAlwaysRun },
 }
 
 const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client }: {

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -73,7 +73,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorDefini
   omitData: { creator: omitDataValidator, defaultInDeploy: false, defaultInValidate: true },
   unknownUser: { creator: (_config, _isSandbox, client) => unknownUser(client), ...defaultAlwaysRun },
   animationRuleRecordType: { creator: () => animationRuleRecordType, ...defaultAlwaysRun },
-  accountSettings: { creator: (_config, _isSandbox, client) => accountSettings(client), ...defaultAlwaysRun },
+  accountSettings: { creator: accountSettings, ...defaultAlwaysRun },
 }
 
 const createSalesforceChangeValidator = ({ config, isSandbox, checkOnly, client }: {

--- a/packages/salesforce-adapter/src/change_validators/account_settings.ts
+++ b/packages/salesforce-adapter/src/change_validators/account_settings.ts
@@ -1,0 +1,64 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange,
+  isInstanceElement } from '@salto-io/adapter-api'
+import { buildSelectQueries, isInstanceOfType, queryClient } from '../filters/utils'
+import { SalesforceRecord } from '../client/types'
+import SalesforceClient from '../client/client'
+
+const { awu } = collections.asynciterable
+const log = logger(module)
+
+const isRecordTypeInvalid = (globalSharingSettings: SalesforceRecord, instance: InstanceElement): boolean => (
+  globalSharingSettings.DefaultAccountAccess !== 'Read'
+  && instance.value.enableAccountOwnerReport !== undefined
+)
+
+const invalidRecordTypeError = (instance: InstanceElement): ChangeError => (
+  {
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: 'You cannot set a value for AccountSettings.enableAccountOwnerReport unless your organization-wide sharing access level for Accounts is set to Private',
+    detailedMessage: `In ${instance.elemID.getFullName()}, enableAccountOwnerReport is set to '${instance.value.enableAccountOwnerReport}' but the organization-wide sharing access level for Accounts is not set to 'Private'.`,
+  }
+)
+
+const changeValidator = (client: SalesforceClient): ChangeValidator => async changes => {
+  const query = await buildSelectQueries('Organization', ['DefaultAccountAccess'])
+  const queryResult = await queryClient(client, query)
+
+  if (queryResult.length !== 1) {
+    log.error(`Expected a single Organization instance. Found ${queryResult ? queryResult.length : 0} instead`)
+    log.error('Unexpected Organization instances: %o', queryResult)
+    return []
+  }
+
+  const changedInstances = changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+
+  return awu(changedInstances)
+    .filter(isInstanceOfType('AccountSettings'))
+    .filter(accountSettingsInstance => isRecordTypeInvalid(queryResult[0], accountSettingsInstance))
+    .map(invalidRecordTypeError)
+    .toArray()
+}
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
+++ b/packages/salesforce-adapter/src/filters/organization_wide_sharing_defaults.ts
@@ -1,0 +1,105 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import _ from 'lodash'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { RemoteFilterCreator } from '../filter'
+import { queryClient } from './utils'
+import { createInstanceElement, getSObjectFieldElement, getTypePath } from '../transformers/transformer'
+import { API_NAME, INSTANCE_FULL_NAME_FIELD, METADATA_TYPE, SALESFORCE } from '../constants'
+import SalesforceClient from '../client/client'
+
+const log = logger(module)
+
+
+const enrichTypeWithFields = async (client: SalesforceClient, type: ObjectType): Promise<void> => {
+  const apiName = type.elemID.typeName // TODO
+  const describeSObjectsResult = await client.describeSObjects([apiName])
+  if (describeSObjectsResult.errors.length !== 0 || describeSObjectsResult.result.length !== 1) {
+    log.warn('describeSObject on %o failed with errors: %o and %o results',
+      apiName,
+      describeSObjectsResult.errors,
+      describeSObjectsResult.result.length)
+    return
+  }
+
+  const [typeDescription] = describeSObjectsResult.result
+
+  const [topLevelFields, nestedFields] = _.partition(typeDescription.fields,
+    field => field.compoundFieldName === undefined)
+
+  const objCompoundFieldNames = _.mapValues(
+    _.groupBy(nestedFields, field => field.compoundFieldName),
+    (_nestedFields, compoundName) => compoundName,
+  )
+
+  const fields = topLevelFields
+    .map(field => getSObjectFieldElement(type, field, { [API_NAME]: apiName }, objCompoundFieldNames))
+
+  type.fields = { ...type.fields, ..._.keyBy(fields, field => _.camelCase(field.name)) }
+}
+
+const createOrganizationType = (): ObjectType => (
+  new ObjectType({
+    elemID: new ElemID(SALESFORCE, 'Organization'),
+    fields: {
+      fullName: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.HIDDEN]: true,
+      [CORE_ANNOTATIONS.UPDATABLE]: false,
+      [METADATA_TYPE]: 'Organization',
+    },
+    isSettings: true,
+    path: getTypePath('Organization'),
+  })
+)
+
+const filterCreator: RemoteFilterCreator = ({ client }) => ({
+  onFetch: async elements => {
+    const objectType = createOrganizationType()
+    await enrichTypeWithFields(client, objectType)
+
+    const queryResult = await queryClient(client, ['SELECT FIELDS(ALL) FROM Organization LIMIT 200'])
+    if (queryResult.length !== 1) {
+      log.error(`Expected Organization object to be a singleton. Got ${queryResult.length} elements`)
+      return
+    }
+
+    const organizationObject = _.mapKeys(queryResult[0], (_value, key) => _.camelCase(key))
+
+    const organizationInstance = createInstanceElement(
+      {
+        [INSTANCE_FULL_NAME_FIELD]: 'OrganizationSettings', // Note: Query results don't have a fullName field
+        ..._.pick(organizationObject, Object.keys(objectType.fields)),
+      },
+      objectType,
+      undefined,
+      {
+        [CORE_ANNOTATIONS.HIDDEN]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: false,
+        [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+      }
+    )
+
+    elements.push(objectType, organizationInstance)
+  },
+})
+
+export default filterCreator

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -317,7 +317,16 @@ export const deployMetadata = async (
 
   const sfDeployRes = await client.deploy(pkgData, { checkOnly })
 
-  log.debug('deploy result: %s', safeJsonStringify(sfDeployRes, undefined, 2))
+  log.debug('deploy result: %s', safeJsonStringify({
+    ...sfDeployRes,
+    details: sfDeployRes.details?.map(detail => ({
+      ...detail,
+      // The test result can be VERY long
+      runTestResult: detail.runTestResult
+        ? safeJsonStringify(detail.runTestResult, undefined, 2).slice(100)
+        : undefined,
+    })),
+  }, undefined, 2))
 
   const { errors, successfulFullNames } = processDeployResponse(
     sfDeployRes, pkg.getDeletionsPackageName(), checkOnly ?? false

--- a/packages/salesforce-adapter/src/transformers/salesforce_types.ts
+++ b/packages/salesforce-adapter/src/transformers/salesforce_types.ts
@@ -197,3 +197,42 @@ export const allMissingSubTypes = [
   lightningComponentBundleSupportedFormFactorsType,
   lightningComponentBundleSupportedFormFactorType,
 ]
+
+export const ORGANIZATION_OBJECT_TYPE = new ObjectType({
+  elemID: new ElemID(SALESFORCE, 'Organization'),
+  fields: {
+    fullName: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultAccountAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCalendarAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCampaignAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultCaseAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultContactAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultLeadAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultOpportunityAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+    DefaultPricebookAccess: {
+      refType: BuiltinTypes.STRING,
+    },
+  },
+  annotations: {
+    // [CORE_ANNOTATIONS.HIDDEN]: true,
+    [CORE_ANNOTATIONS.UPDATABLE]: false,
+  },
+  isSettings: true,
+  path: [...subTypesPath, 'Organization'],
+})

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -98,6 +98,7 @@ export type ChangeValidatorName = (
   | 'omitData'
   | 'unknownUser'
   | 'animationRuleRecordType'
+  | 'accountSettings'
 )
 
 export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -587,6 +588,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     omitData: { refType: BuiltinTypes.BOOLEAN },
     unknownUser: { refType: BuiltinTypes.BOOLEAN },
     animationRuleRecordType: { refType: BuiltinTypes.BOOLEAN },
+    accountSettings: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
@@ -1,0 +1,84 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { toChange } from '@salto-io/adapter-api'
+import * as filterUtilsModule from '../../src/filters/utils'
+import { CUSTOM_OBJECT_ID_FIELD } from '../../src/constants'
+import { mockTypes } from '../mock_elements'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import changeValidatorCreator from '../../src/change_validators/account_settings'
+import mockAdapter from '../adapter'
+
+jest.mock('../../src/filters/utils', () => ({
+  ...jest.requireActual('../../src/filters/utils'),
+  queryClient: jest.fn(),
+}))
+
+const mockedFilterUtils = jest.mocked(filterUtilsModule)
+
+const setMockQueryResult = (defaultAccountAccess: string): void => {
+  mockedFilterUtils.queryClient.mockResolvedValue([{
+    [CUSTOM_OBJECT_ID_FIELD]: 'SomeId',
+    DefaultAccountAccess: defaultAccountAccess,
+  }])
+}
+
+describe('Account settings validator', () => {
+  const instanceBefore = createInstanceElement({ fullName: 'whatever' }, mockTypes.AccountSettings)
+  const { client } = mockAdapter({})
+  const changeValidator = changeValidatorCreator(client)
+
+  describe('When the global setting is \'Private\'', () => {
+    beforeEach(() => {
+      setMockQueryResult('Read')
+    })
+
+    it('Should pass validation if enableAccountOwnerReport exists', async () => {
+      const instanceAfter = instanceBefore.clone()
+      instanceAfter.value.enableAccountOwnerReport = true
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toBeEmpty()
+    })
+    it('Should pass validation if enableAccountOwnerReport does not exist', async () => {
+      const instanceAfter = instanceBefore.clone()
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toBeEmpty()
+    })
+  })
+
+  describe('When the global setting is not \'Private\'', () => {
+    beforeEach(() => {
+      setMockQueryResult('Edit')
+    })
+
+    it('Should fail validation if enableAccountOwnerReport exists', async () => {
+      const instanceAfter = instanceBefore.clone()
+      instanceAfter.value.enableAccountOwnerReport = true
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toHaveLength(1)
+      expect(errors).toIncludeAllPartialMembers([{ elemID: instanceBefore.elemID }])
+    })
+    it('Should pass validation if enableAccountOwnerReport does not exist', async () => {
+      const instanceAfter = instanceBefore.clone()
+      const change = toChange({ before: instanceBefore, after: instanceAfter })
+      const errors = await changeValidator([change])
+      expect(errors).toBeEmpty()
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/account_settings.test.ts
@@ -14,70 +14,60 @@
 * limitations under the License.
 */
 
-import { toChange } from '@salto-io/adapter-api'
-import * as filterUtilsModule from '../../src/filters/utils'
-import { CUSTOM_OBJECT_ID_FIELD } from '../../src/constants'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ReadOnlyElementsSource, toChange } from '@salto-io/adapter-api'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import changeValidatorCreator from '../../src/change_validators/account_settings'
-import mockAdapter from '../adapter'
+import { ORGANIZATION_OBJECT_TYPE } from '../../src/transformers/salesforce_types'
 
-jest.mock('../../src/filters/utils', () => ({
-  ...jest.requireActual('../../src/filters/utils'),
-  queryClient: jest.fn(),
-}))
-
-const mockedFilterUtils = jest.mocked(filterUtilsModule)
-
-const setMockQueryResult = (defaultAccountAccess: string): void => {
-  mockedFilterUtils.queryClient.mockResolvedValue([{
-    [CUSTOM_OBJECT_ID_FIELD]: 'SomeId',
-    DefaultAccountAccess: defaultAccountAccess,
-  }])
+const mockElementsSource = (defaultAccountAccess: string): ReadOnlyElementsSource => {
+  const element = createInstanceElement(
+    {
+      fullName: 'OrganizationSettings',
+      defaultAccountAccess,
+    },
+    ORGANIZATION_OBJECT_TYPE
+  )
+  return buildElementsSourceFromElements([element])
 }
 
 describe('Account settings validator', () => {
   const instanceBefore = createInstanceElement({ fullName: 'whatever' }, mockTypes.AccountSettings)
-  const { client } = mockAdapter({})
-  const changeValidator = changeValidatorCreator(client)
+  const changeValidator = changeValidatorCreator()
 
   describe('When the global setting is \'Private\'', () => {
-    beforeEach(() => {
-      setMockQueryResult('Read')
-    })
-
+    const elementsSource = mockElementsSource('Read')
     it('Should pass validation if enableAccountOwnerReport exists', async () => {
       const instanceAfter = instanceBefore.clone()
       instanceAfter.value.enableAccountOwnerReport = true
       const change = toChange({ before: instanceBefore, after: instanceAfter })
-      const errors = await changeValidator([change])
+      const errors = await changeValidator([change], elementsSource)
       expect(errors).toBeEmpty()
     })
     it('Should pass validation if enableAccountOwnerReport does not exist', async () => {
       const instanceAfter = instanceBefore.clone()
       const change = toChange({ before: instanceBefore, after: instanceAfter })
-      const errors = await changeValidator([change])
+      const errors = await changeValidator([change], elementsSource)
       expect(errors).toBeEmpty()
     })
   })
 
   describe('When the global setting is not \'Private\'', () => {
-    beforeEach(() => {
-      setMockQueryResult('Edit')
-    })
+    const elementsSource = mockElementsSource('Edit')
 
     it('Should fail validation if enableAccountOwnerReport exists', async () => {
       const instanceAfter = instanceBefore.clone()
       instanceAfter.value.enableAccountOwnerReport = true
       const change = toChange({ before: instanceBefore, after: instanceAfter })
-      const errors = await changeValidator([change])
+      const errors = await changeValidator([change], elementsSource)
       expect(errors).toHaveLength(1)
       expect(errors).toIncludeAllPartialMembers([{ elemID: instanceBefore.elemID }])
     })
     it('Should pass validation if enableAccountOwnerReport does not exist', async () => {
       const instanceAfter = instanceBefore.clone()
       const change = toChange({ before: instanceBefore, after: instanceAfter })
-      const errors = await changeValidator([change])
+      const errors = await changeValidator([change], elementsSource)
       expect(errors).toBeEmpty()
     })
   })

--- a/packages/salesforce-adapter/test/filters/organization_wide_sharing_defaults.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_wide_sharing_defaults.test.ts
@@ -1,0 +1,168 @@
+/*
+*                      Copyright 2023 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, ElemID } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/organization_wide_sharing_defaults'
+import { FilterWith } from '../../src/filter'
+import mockAdapter from '../adapter'
+import { defaultFilterContext } from '../utils'
+import * as filterUtilsModule from '../../src/filters/utils'
+import { CUSTOM_OBJECT_ID_FIELD, SALESFORCE } from '../../src/constants'
+
+jest.mock('../../src/filters/utils', () => ({
+  ...jest.requireActual('../../src/filters/utils'),
+  queryClient: jest.fn(),
+}))
+
+
+describe('When fetching organization-wide defaults', () => {
+  const mockedFilterUtils = jest.mocked(filterUtilsModule)
+  const { client, connection } = mockAdapter({})
+  let filter: FilterWith<'onFetch'>
+
+  const setDescribeSObjectsReturnValue = (fields: string[]):void => {
+    const objectDefaults = {
+      activateable: false,
+      childRelationships: [],
+      compactLayoutable: false,
+      createable: false,
+      custom: false,
+      customSetting: false,
+      deletable: false,
+      deprecatedAndHidden: false,
+      feedEnabled: false,
+      label: 'whatever',
+      labelPlural: 'whatevers',
+      layoutable: false,
+      mergeable: false,
+      mruEnabled: false,
+      namedLayoutInfos: [],
+      queryable: false,
+      recordTypeInfos: [],
+      replicateable: false,
+      retrieveable: false,
+      searchable: false,
+      searchLayoutable: false,
+      supportedScopes: [],
+      triggerable: false,
+      undeletable: false,
+      updateable: false,
+      urls: {},
+    }
+    const fieldDefaults = {
+      aggregatable: false,
+      autoNumber: false,
+      byteLength: 0,
+      calculated: false,
+      cascadeDelete: false,
+      caseSensitive: false,
+      createable: false,
+      custom: false,
+      defaultedOnCreate: false,
+      dependentPicklist: false,
+      deprecatedAndHidden: false,
+      externalId: false,
+      filterable: false,
+      groupable: false,
+      htmlFormatted: false,
+      idLookup: false,
+      length: 0,
+      nameField: false,
+      namePointing: false,
+      label: 'whatever',
+      nillable: false,
+      permissionable: false,
+      polymorphicForeignKey: false,
+      queryByDistance: false,
+      restrictedPicklist: false,
+      scale: 1,
+      searchPrefilterable: false,
+      soapType: 'xsd:string',
+      sortable: false,
+      type: 'string',
+      unique: false,
+      updateable: false,
+    } as const
+    connection.soap.describeSObjects.mockResolvedValue([
+      {
+        ...objectDefaults,
+        name: 'Organization',
+        fields: [
+          {
+            ...fieldDefaults,
+            name: 'name',
+            nameField: true,
+          },
+          ...fields.map(fieldName => ({ name: fieldName, ...fieldDefaults })),
+        ],
+      },
+    ])
+  }
+
+  beforeAll(() => {
+    filter = filterCreator({
+      config: { ...defaultFilterContext },
+      client,
+    }) as typeof filter
+  })
+
+  beforeEach(() => {
+    mockedFilterUtils.queryClient.mockResolvedValue([{
+      [CUSTOM_OBJECT_ID_FIELD]: 'SomeId',
+      DefaultAccountAccess: 'Edit',
+      DefaultContactAccess: 'ControlledByParent',
+      DefaultOpportunityAccess: 'None',
+      DefaultLeadAccess: 'ReadEditTransfer',
+      DefaultCaseAccess: 'None',
+      DefaultCalendarAccess: 'HideDetailsInsert',
+      DefaultPricebookAccess: 'ReadSelect',
+      DefaultCampaignAccess: 'All',
+      SomeIrrelevantField: 'SomeIrrelevantValue',
+    }])
+    setDescribeSObjectsReturnValue([
+      'defaultAccountAccess',
+      'defaultCalendarAccess',
+      'defaultCampaignAccess',
+      'defaultCaseAccess',
+      'defaultContactAccess',
+      'defaultLeadAccess',
+      'defaultOpportunityAccess',
+    ])
+  })
+
+  it('should fetch them', async () => {
+    const elements: Element[] = []
+    await filter.onFetch(elements)
+    expect(elements).toHaveLength(2)
+    expect(elements).toIncludeAllPartialMembers([
+      {
+        elemID: new ElemID(SALESFORCE, 'Organization'),
+      },
+      {
+        elemID: new ElemID(SALESFORCE, 'Organization', 'instance', '_config'),
+        value: {
+          defaultAccountAccess: 'Edit',
+          defaultCalendarAccess: 'HideDetailsInsert',
+          defaultCampaignAccess: 'All',
+          defaultCaseAccess: 'None',
+          defaultContactAccess: 'ControlledByParent',
+          defaultLeadAccess: 'ReadEditTransfer',
+          defaultOpportunityAccess: 'None',
+          fullName: 'OrganizationSettings',
+        },
+      },
+    ])
+  })
+})

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -382,6 +382,18 @@ export const mockTypes = {
       },
     }
   ),
+  AccountSettings: new ObjectType({
+    elemID: new ElemID(SALESFORCE, 'AccountSettings'),
+    fields: {
+      enableAccountOwnerReport: {
+        refType: BuiltinTypes.BOOLEAN,
+      },
+    },
+    annotations: {
+      metadataType: 'AccountSettings',
+    },
+    isSettings: true,
+  }),
 }
 
 export const lwcJsResourceContent = "import { LightningElement } from 'lwc';\nexport default class BikeCard extends LightningElement {\n   name = 'Electra X4';\n   description = 'A sweet bike built for comfort.';\n   category = 'Mountain';\n   material = 'Steel';\n   price = '$2,700';\n   pictureUrl = 'https://s3-us-west-1.amazonaws.com/sfdc-demo/ebikes/electrax4.jpg';\n }"

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -233,9 +233,8 @@ export const buildAdaptersConfigSource = async ({
       }
       await updateValidationErrorsCache(validationErrorsMap, elementsSource, naclSource)
     },
-    getElementNaclFiles: async adapter => naclSource.getElementNaclFiles(
-      new ElemID(adapter, ElemID.CONFIG_NAME, 'instance', ElemID.CONFIG_NAME)
-    ),
+    getElementNaclFiles: async adapter => (await naclSource.listNaclFiles())
+      .filter(filePath => filePath.startsWith(path.join(...CONFIG_PATH, adapter).concat(path.sep))),
 
     getErrors: async () => {
       const validationErrors = await awu(validationErrorsMap.values()).flat().toArray()

--- a/packages/workspace/test/workspace/adapters_config.test.ts
+++ b/packages/workspace/test/workspace/adapters_config.test.ts
@@ -215,9 +215,9 @@ describe('adapters config', () => {
   })
 
   it('getElementNaclFiles should return the configuration files', async () => {
-    mockNaclFilesSource.getElementNaclFiles.mockResolvedValue(['salto.config/adapters/a/b', 'salto.config/adapters/c'])
+    mockNaclFilesSource.listNaclFiles.mockResolvedValue(['salto.config/adapters/salesforce/a/b', 'salto.config/adapters/salesforce/c', 'salto.config/adapters/dummy/d'])
     const paths = await configSource.getElementNaclFiles('salesforce')
-    expect(paths).toEqual(['salto.config/adapters/a/b', 'salto.config/adapters/c'])
+    expect(paths).toEqual(['salto.config/adapters/salesforce/a/b', 'salto.config/adapters/salesforce/c'])
   })
 
   describe('configOverrides', () => {


### PR DESCRIPTION
Add a change validator for `AccountSettings.enableAccountOwnerReport`. This field may only exist if the global account sharing policy is 'Private'

PR Chain:
[Fetch org wide sharing defaults](https://github.com/salto-io/salto/pull/3829)


---

The actual value of the global account sharing setting is 'Read', 'Edit', etc. It is never actually set to 'Private' in the API data, but rather translated to other values (including 'Private') in the Salesforce UI.

---
_Release Notes_: 
Salesforce: Improved pre-deploy validation of account settings.

---
_User Notifications_: 
N/A
